### PR TITLE
Add more properties to user search response

### DIFF
--- a/helpers/models_helper.rb
+++ b/helpers/models_helper.rb
@@ -78,6 +78,15 @@ module ModelsHelper
         :friendship_url => {
           :type => Const::STRING,
           :required => true
+        },
+        :country => {
+          :type => Const::STRING
+        },
+        :city => {
+          :type => Const::STRING
+        },
+        :training_for => {
+          :type => Const::STRING
         }
       }
     }
@@ -145,6 +154,9 @@ module ModelsHelper
           :type => Const::STRING
         },
         :city => {
+          :type => Const::STRING
+        },
+        :training_for => {
           :type => Const::STRING
         },
         :level => {


### PR DESCRIPTION
The user search on mobiles is currently missing some fields that are
present in the web UI, such as user location and training target. Add
those to the API response to allow making the mobile UX closer to web.

Corresponding code changes: https://github.com/HeiaHeia/HeiaHeia/pull/3549