### PR TITLE
New filter parameter for GET /v2/notifications

### DIFF
--- a/views/v2/api-docs/notifications.json.erb
+++ b/views/v2/api-docs/notifications.json.erb
@@ -21,6 +21,12 @@
               "description":"ID of the last seen notification"
             },
             {
+              "name":"before",
+              "paramType":"query",
+              "dataType":"long",
+              "description":"Return only notifications whose ID is less than this value"
+            },
+            {
               "name":"unread",
               "paramType":"query",
               "dataType":"boolean"


### PR DESCRIPTION
The before filter allows paging notifications from newest to oldest.