### PR TITLE
Survey API changes

### DIFF
--- a/helpers/models_helper.rb
+++ b/helpers/models_helper.rb
@@ -2304,6 +2304,10 @@ module ModelsHelper
           :type => Const::LONG,
           :required => true
         },
+        :complete => {
+          :type => Const::BOOLEAN,
+          :required => true
+        },
         :date => {
           :type => Const::DATE,
           :required => true

--- a/views/v2/api-docs/planned_surveys.json.erb
+++ b/views/v2/api-docs/planned_surveys.json.erb
@@ -38,6 +38,14 @@
       "description":"Operations about planned surveys",
       "operations":[
         {
+          "httpMethod":"GET",
+          "summary":"Return planned survey",
+          "responseClass":"PlannedSurvey",
+          "nickname":"show",
+          "parameters":[],
+          "errorResponses":<%= responses(404) %>
+        },
+        {
           "httpMethod":"DELETE",
           "summary":"Delete planned survey",
           "responseClass":"void",

--- a/views/v2/api-docs/survey_results.json.erb
+++ b/views/v2/api-docs/survey_results.json.erb
@@ -23,6 +23,12 @@
               "dataType": "long",
               "required": false,
               "description": "Return only results associated with given survey. The year parameter is ignored when survey_id is present."
+            },
+            {
+              "name": "planned_survey_id",
+              "paramType": "form",
+              "dataType": "long",
+              "description": "Fetches survey results associated with given planned survey. In practise only returns incomplete results and cannot return more than one entry."
             }
           ],
           "errorResponses":<%= responses(400) %>
@@ -43,6 +49,12 @@
               "name":"planned_survey_id",
               "paramType":"form",
               "dataType":"long"
+            },
+            {
+              "name":"complete",
+              "description":"Whether the survey was fully completed or only in part. Default is true",
+              "paramType":"form",
+              "dataType":"boolean"
             },
             {
               "name":"answers[][question_id]",
@@ -86,6 +98,38 @@
             }
           ],
           "errorResponses":<%= responses(404) %>
+        },
+        {
+          "httpMethod":"PUT",
+          "summary":"Update existing incomplete survey result",
+          "responseClass":"SurveyResult",
+          "nickname":"update",
+          "parameters":[
+            {
+              "name":"complete",
+              "description":"Whether the survey was fully completed or only in part. Existing state is not changed when this parameter is missing.",
+              "paramType":"form",
+              "dataType":"boolean"
+            },
+            {
+              "name":"answers[][question_id]",
+              "paramType":"form",
+              "dataType":"<%= Const::LONG %>",
+              "required":true
+            },
+            {
+              "name":"answers[][option_ids][]",
+              "paramType":"form",
+              "dataType":"<%= Const::LONG %>",
+              "required":true
+            },
+            {
+              "name":"answers[][note]",
+              "paramType":"form",
+              "dataType":"<%= Const::TEXT %>"
+            }
+          ],
+          "errorResponses":<%= responses(400, 404) %>
         },
         {
           "httpMethod":"DELETE",


### PR DESCRIPTION
* Allows fetching individual planned survey by id with GET /planned_surveys/id
* Survey results objects now have complete=true|false property
* Existing survey results can be updated with PUT /survey_results/id
* completed property can be provided when creating or updating survey result
* Survey results may be filtered by associated planned survey id